### PR TITLE
Add basic netstat functionality

### DIFF
--- a/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
+++ b/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
@@ -31,7 +31,6 @@ rand = "0.8"
 serde_json = "1.0"
 sha2 = "0.9.8"
 netstat2 = "0.9.1"
-itertools = "0.13.0"
 
 [dependencies.minreq]
 version = "2.4.2"

--- a/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
+++ b/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
@@ -30,6 +30,8 @@ path-clean = "0.1.0"
 rand = "0.8"
 serde_json = "1.0"
 sha2 = "0.9.8"
+netstat2 = "0.9.1"
+itertools = "0.13.0"
 
 [dependencies.minreq]
 version = "2.4.2"

--- a/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
@@ -17,6 +17,7 @@ mod jobs;
 mod ls;
 mod mkdir;
 mod mv;
+mod netstat;
 mod payloadvars;
 mod portscan;
 mod profiles;

--- a/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-use itertools::Itertools;
 use crate::agent::AgentTask;
 use crate::mythic_success;
 use netstat2::{get_sockets_info, AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo};
@@ -23,7 +22,7 @@ pub struct NetworkListingEntry {
     pub remote_port: Option<u16>,
 
     /// Associated PIDs
-    pub associated_pids: String,
+    pub associated_pids: Vec<u32>,
 
     /// State
     pub state: Option<String>,
@@ -44,7 +43,7 @@ pub fn netstat(task: &AgentTask) -> Result<(serde_json::Value), Box<dyn std::err
                 local_port: tcp_si.local_port,
                 remote_addr: Some(tcp_si.remote_addr.to_string()),
                 remote_port: Some(tcp_si.remote_port),
-                associated_pids: Itertools::join(&mut si.associated_pids.iter(), ","),
+                associated_pids: si.associated_pids,
                 state: Some(tcp_si.state.to_string()),
             }),
             ProtocolSocketInfo::Udp(udp_si) => conn.push(NetworkListingEntry {
@@ -53,7 +52,7 @@ pub fn netstat(task: &AgentTask) -> Result<(serde_json::Value), Box<dyn std::err
                 local_port: udp_si.local_port,
                 remote_addr: None,
                 remote_port: None,
-                associated_pids: Itertools::join(&mut si.associated_pids.iter(), ","),
+                associated_pids: si.associated_pids,
                 state: None,
             }),
         }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
@@ -1,0 +1,65 @@
+use serde::Serialize;
+use itertools::Itertools;
+use crate::agent::AgentTask;
+use crate::mythic_success;
+use netstat2::{get_sockets_info, AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo};
+
+/// Struct holding the information for network connections
+#[derive(Default, Serialize)]
+pub struct NetworkListingEntry {
+    /// Protocol
+    pub proto: String,
+
+    /// Local address
+    pub local_addr: String,
+
+    /// Local Port
+    pub local_port: u16,
+
+    /// Remote address
+    pub remote_addr: Option<String>,
+
+    /// Remote port
+    pub remote_port: Option<u16>,
+
+    /// Associated PIDs
+    pub associated_pids: String,
+
+    /// State
+    pub state: Option<String>,
+}
+
+pub fn netstat(task: &AgentTask) -> Result<(serde_json::Value), Box<dyn std::error::Error>> { 
+    let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
+    let proto_flags = ProtocolFlags::TCP | ProtocolFlags::UDP;
+    let sockets_info = get_sockets_info(af_flags, proto_flags)?;
+
+    let mut conn: Vec<NetworkListingEntry> = Vec::new();
+
+    for si in sockets_info {
+        match si.protocol_socket_info {
+            ProtocolSocketInfo::Tcp(tcp_si) => conn.push(NetworkListingEntry {
+                proto: "TCP".to_string(),
+                local_addr: tcp_si.local_addr.to_string(),
+                local_port: tcp_si.local_port,
+                remote_addr: Some(tcp_si.remote_addr.to_string()),
+                remote_port: Some(tcp_si.remote_port),
+                associated_pids: Itertools::join(&mut si.associated_pids.iter(), ","),
+                state: Some(tcp_si.state.to_string()),
+            }),
+            ProtocolSocketInfo::Udp(udp_si) => conn.push(NetworkListingEntry {
+                proto: "UDP".to_string(),
+                local_addr: udp_si.local_addr.to_string(),
+                local_port: udp_si.local_port,
+                remote_addr: None,
+                remote_port: None,
+                associated_pids: Itertools::join(&mut si.associated_pids.iter(), ","),
+                state: None,
+            }),
+        }
+    }
+
+    let user_output = serde_json::to_string(&conn)?;
+    /// Return the output to Mythic
+    Ok(mythic_success!(task.id, user_output))
+}

--- a/Payload_Type/thanatos/thanatos/agent_code/src/tasking.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/tasking.rs
@@ -9,7 +9,7 @@ use std::sync::{
 
 // Import all of the commands
 use crate::{
-    cat, cd, cp, download, exit, getenv, getprivs, jobs, ls, mkdir, mv, portscan, ps, pwd,
+    cat, cd, cp, download, exit, getenv, getprivs, jobs, ls, mkdir, mv, netstat, portscan, ps, pwd,
     redirect, rm, setenv, shell, sleep, ssh, unsetenv, upload, workinghours,
 };
 
@@ -360,6 +360,11 @@ fn process_task(task: &agent::AgentTask) -> serde_json::Value {
         },
 
         "mv" => match mv::move_file(task) {
+            Ok(res) => res,
+            Err(e) => mythic_error!(task.id, e.to_string()),
+        },
+
+        "netstat" => match netstat::netstat(task) {
             Ok(res) => res,
             Err(e) => mythic_error!(task.id, e.to_string()),
         },

--- a/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
+++ b/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
@@ -1,0 +1,41 @@
+from mythic_container.MythicCommandBase import (
+    BrowserScript,
+    TaskArguments,
+    CommandBase,
+    CommandAttributes,
+    SupportedOS,
+    MythicTask,
+    PTTaskMessageAllData,
+    PTTaskProcessResponseMessageResponse,
+)
+
+
+class NetstatArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = []
+
+    async def parse_arguments(self):
+        pass
+
+
+class NetstatCommand(CommandBase):
+    cmd = "netstat"
+    needs_admin = False
+    help_cmd = "netstat"
+    description = "Get all active network connections & sockets"
+    version = 1
+    author = "@maclarel"
+    argument_class = NetstatArguments
+    attackmapping = [""]
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.Linux, SupportedOS.Windows],
+    )
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        return task
+
+    async def process_response(
+        self, task: PTTaskMessageAllData, response: str
+    ) -> PTTaskProcessResponseMessageResponse:
+        pass

--- a/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
+++ b/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
@@ -27,7 +27,7 @@ class NetstatCommand(CommandBase):
     version = 1
     author = "@maclarel"
     argument_class = NetstatArguments
-    attackmapping = [""]
+    attackmapping = ["T1049"]
     attributes = CommandAttributes(
         supported_os=[SupportedOS.Linux, SupportedOS.Windows],
     )

--- a/documentation-payload/thanatos/commands/netstat.md
+++ b/documentation-payload/thanatos/commands/netstat.md
@@ -6,7 +6,7 @@ hidden = true
 +++
 
 ## Description
-Report on all active network connections. Note that this requires the agent to be running in a `root` context.
+Report on all active network connections. Note that this may require the agent to be running in a `root` context for complete enumeration.
 
 ## Usage
 ```

--- a/documentation-payload/thanatos/commands/netstat.md
+++ b/documentation-payload/thanatos/commands/netstat.md
@@ -1,0 +1,53 @@
++++
+title = "netstat"
+chapter = false
+weight = 103
+hidden = true
++++
+
+## Description
+Report on all active network connections. Note that this requires the agent to be running in a `root` context.
+
+## Usage
+```
+netstat
+```
+
+### Examples
+```
+netstat
+```
+```
+[
+    {
+        "proto": "TCP",
+        "local_addr": "127.0.0.53",
+        "local_port": 53,
+        "remote_addr": "0.0.0.0",
+        "remote_port": 0,
+        "associated_pids": "",
+        "state": "LISTEN"
+    },
+    {
+        "proto": "TCP",
+        "local_addr": "0.0.0.0",
+        "local_port": 22,
+        "remote_addr": "0.0.0.0",
+        "remote_port": 0,
+        "associated_pids": "",
+        "state": "LISTEN"
+    },
+    {
+        "proto": "TCP",
+        "local_addr": "10.0.0.1",
+        "local_port": 22,
+        "remote_addr": "10.0.0.2",
+        "remote_port": 40803,
+        "associated_pids": "",
+        "state": "ESTABLISHED"
+    }
+]
+```
+
+## MITRE ATT&CK Mapping
+ - T1049


### PR DESCRIPTION
This PR adds basic `netstat` functionality to Thanatos in order to facilitate enumeration of local network connections and sockets. This is accomplished using https://github.com/ohadravid/netstat2-rs, and data is returned to Mythic in JSON format for easy manipulation. 

Invocation does not currently accept any additional parameters, and output is returned to Mythic in a JSON format so it can be easily dumped for further external automation/manipulation. Example:

```
netstat
```
```
[
    {
        "proto": "TCP",
        "local_addr": "127.0.0.53",
        "local_port": 53,
        "remote_addr": "0.0.0.0",
        "remote_port": 0,
        "associated_pids": "",
        "state": "LISTEN"
    },
    {
        "proto": "UDP",
        "local_addr": "10.0.0.1",
        "local_port": 68,
        "remote_addr": null,
        "remote_port": null,
        "associated_pids": "",
        "state": null
    },
    {
        "proto": "TCP",
        "local_addr": "10.0.0.1",
        "local_port": 22,
        "remote_addr": "10.0.0.2",
        "remote_port": 40803,
        "associated_pids": "",
        "state": "ESTABLISHED"
    },
    ...
]
```

Please note that I have not been able to properly test this on Windows, however this has been validated through testing on multiple Linux systems.

<3 from GitHub's Red Team