### PR TITLE
Replace deprecated chrono functions

### DIFF
--- a/Payload_Type/thanatos/thanatos/agent_code/src/agent.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/agent.rs
@@ -239,13 +239,16 @@ impl Agent {
             if now < working_start {
                 // Calculate the sleep interval if the current time is before
                 // the working hours
-                let delta = Duration::seconds(working_start.timestamp() - now.timestamp());
+                let delta = Duration::seconds(
+                    working_start.and_utc().timestamp() - now.and_utc().timestamp(),
+                );
                 sleep_time = delta.to_std().unwrap();
             } else if now > working_end {
                 // Calculate the sleep interval if the current time as after the
                 // working hours
                 let next_start = working_start.checked_add_signed(Duration::days(1)).unwrap();
-                let delta = Duration::seconds(next_start.timestamp() - now.timestamp());
+                let delta =
+                    Duration::seconds(next_start.and_utc().timestamp() - now.and_utc().timestamp());
                 sleep_time = delta.to_std().unwrap();
             }
 

--- a/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
@@ -85,11 +85,13 @@ fn run_beacon() -> Result<(), Box<dyn Error>> {
 
         // Check the agent's working hours and don't check in if not in the configured time frame
         if now < working_start {
-            let delta = Duration::seconds(working_start.timestamp() - now.timestamp());
+            let delta =
+                Duration::seconds(working_start.and_utc().timestamp() - now.and_utc().timestamp());
             std::thread::sleep(delta.to_std()?);
         } else if now > working_end {
             let next_start = working_start.checked_add_signed(Duration::days(1)).unwrap();
-            let delta = Duration::seconds(next_start.timestamp() - now.timestamp());
+            let delta =
+                Duration::seconds(next_start.and_utc().timestamp() - now.and_utc().timestamp());
             std::thread::sleep(delta.to_std()?);
         }
 


### PR DESCRIPTION
Removes functions from the chrono crate which are now deprecated and
replaces them with the supported variant.

This removes calls to [NaiveDateTime.timestamp()](https://docs.rs/chrono/latest/chrono/struct.NaiveDateTime.html#method.timestamp)
and replaces them with the supported `.and_utc().timestamp()` call
chain.
