### PR TITLE
Miscellaneous refactoring

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,6 @@ jobs:
         working-directory: ${{ env.THANATOS_PATH }}/${{ env.AGENT_CODE }}
         run: cargo check --color always --all-targets --all-features
         env:
-          RUSTFLAGS: "--cfg http"
           UUID: ""
           AESPSK: ""
           callback_host: ""
@@ -83,7 +82,6 @@ jobs:
         working-directory: ${{ env.THANATOS_PATH }}/${{ env.AGENT_CODE }}
         run: cargo fmt -- --color always --check
         env:
-          RUSTFLAGS: "--cfg http"
           UUID: ""
           AESPSK: ""
           callback_host: ""
@@ -122,7 +120,6 @@ jobs:
         working-directory: ${{ env.THANATOS_PATH }}/${{ env.AGENT_CODE }}
         run: cargo clippy --color always --all-features --all-targets -- -D warnings
         env:
-          RUSTFLAGS: "--cfg http"
           UUID: ""
           AESPSK: ""
           callback_host: ""

--- a/Payload_Type/thanatos/thanatos/agent_code/src/getprivs.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/getprivs.rs
@@ -112,7 +112,7 @@ pub fn get_privileges(task: &AgentTask) -> Result<serde_json::Value, Box<dyn Err
         // Grab the SELinux policy
         if let Ok(f) = std::fs::File::open("/etc/selinux/config") {
             let reader = std::io::BufReader::new(f);
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 if line.starts_with("SELINUXTYPE=") {
                     let policy = line.split('=').last().unwrap();
                     output.push_str(format!("policy: {}\n", policy).as_str());

--- a/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/netstat.rs
@@ -59,6 +59,6 @@ pub fn netstat(task: &AgentTask) -> Result<serde_json::Value, Box<dyn std::error
     }
 
     let user_output = serde_json::to_string(&conn)?;
-    /// Return the output to Mythic
+    // Return the output to Mythic
     Ok(mythic_success!(task.id, user_output))
 }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
@@ -9,9 +9,9 @@ use openssl::rsa;
 use serde::Deserialize;
 use serde_json::json;
 use sha2::Sha256;
+use http::{profilevars, HTTPProfile};
 
 // Import the http profile
-#[cfg(http)]
 mod http;
 
 /// Struct holding the response for a key exchange
@@ -72,22 +72,10 @@ impl Profile {
     /// Generate a new C2 profile for the agent
     /// * `uuid` - Initial configured UUID
     pub fn new(uuid: String) -> Self {
-        // Create a list of configured profiles
-        let mut profiles: Vec<Box<dyn C2Profile>> = Vec::new();
-
-        // HTTP profile specified
-        #[cfg(http)]
-        {
-            use http::{profilevars, HTTPProfile};
-
-            // Append the HTTP profile information
-            profiles.push(Box::new(HTTPProfile::new(&profilevars::cb_host())));
-        }
-
         // Return a new `Profile` object
         Self {
             callback_uuid: uuid,
-            profiles,
+            profiles: vec![Box::new(HTTPProfile::new(&profilevars::cb_host()))],
             active: 0,
         }
     }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
@@ -5,11 +5,11 @@ use std::error::Error;
 use aes::Aes256;
 use block_modes::{block_padding::Pkcs7, BlockMode, Cbc};
 use hmac::{Hmac, Mac, NewMac};
+use http::{profilevars, HTTPProfile};
 use openssl::rsa;
 use serde::Deserialize;
 use serde_json::json;
 use sha2::Sha256;
-use http::{profilevars, HTTPProfile};
 
 // Import the http profile
 mod http;
@@ -35,13 +35,13 @@ struct KeyExchangeReponse {
 #[derive(Debug, Deserialize)]
 pub struct CheckinResponse {
     /// Status of the checkin (success, error)
-    pub status: String,
+    pub _status: String,
 
     /// New agent UUID
     pub id: String,
 
     /// Action field
-    pub action: String,
+    pub _action: String,
 }
 
 /// Trait which C2 profiles implement in order to connect to Mythic

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ssh/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ssh/mod.rs
@@ -23,13 +23,13 @@ pub struct Credentials {
     pub account: String,
 
     /// Comment in the Mythic credentials
-    pub comment: String,
+    pub _comment: String,
 
     /// Credential for authentication
     pub credential: String,
 
     /// Realm this credential is from
-    pub realm: String,
+    pub _realm: String,
 
     /// Credential type
     #[serde(alias = "type")]

--- a/Payload_Type/thanatos/thanatos/mythic/agent_functions/builder.py
+++ b/Payload_Type/thanatos/thanatos/mythic/agent_functions/builder.py
@@ -133,9 +133,6 @@ class Thanatos(PayloadType):
             # Start formulating the rust flags
             rustflags = []
 
-            # Add the C2 profile to the compile flags
-            rustflags.append(f"--cfg {profile}")
-
             # Check for static linking
             abi = "gnu"
             if self.selected_os == SupportedOS.Linux:

--- a/Payload_Type/thanatos/thanatos/mythic/agent_functions/builder.py
+++ b/Payload_Type/thanatos/thanatos/mythic/agent_functions/builder.py
@@ -269,6 +269,11 @@ class Thanatos(PayloadType):
                 payload_path = (
                     f"{agent_build_path.name}/target/{target_os}/release/{target_name}"
                 )
+            else:
+                resp.set_build_stderr(
+                    "Unknown output parameter value: {self.get_parameter('output')}"
+                )
+                return resp
 
             with open(payload_path, "rb") as f:
                 resp.payload = f.read()

--- a/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
+++ b/Payload_Type/thanatos/thanatos/mythic/agent_functions/netstat.py
@@ -1,5 +1,4 @@
 from mythic_container.MythicCommandBase import (
-    BrowserScript,
     TaskArguments,
     CommandBase,
     CommandAttributes,


### PR DESCRIPTION
Project refactoring to remove lint and compile warnings.

## Changes
- 0e93927 Adds else case in payload builder to satisfy pylint warning.
- 0ef7f64 Removes custom `cfg` directive for profile conditional compilation.
- c6ad959 Prefixes unused variables with an underscore to silence Rust compile warnings.
- 11f45bc Adds error handling when reading the SELinux config in the `getprivs` command.
- 9fbd60b Removes unused BrowserScript import from netstat.py.
- 1c27d34 Changes doc comment in src/netstat.rs to be a regular inline comment.