### PR TITLE
Fix agent failing after initial checkin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This changelog file adheres to [keepachangelog](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue where the agent will exit after performing the initial checkin [51e1554](https://github.com/MythicAgents/thanatos/commit/51e1554e7e6b9c96daf5a3bc44e44f5c714e17b0).
+
 ## [0.1.11] - 2024-12-19
 
 ### Fixed

--- a/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/profiles/mod.rs
@@ -35,13 +35,15 @@ struct KeyExchangeReponse {
 #[derive(Debug, Deserialize)]
 pub struct CheckinResponse {
     /// Status of the checkin (success, error)
-    pub _status: String,
+    #[allow(unused)]
+    pub status: String,
 
     /// New agent UUID
     pub id: String,
 
     /// Action field
-    pub _action: String,
+    #[allow(unused)]
+    pub action: String,
 }
 
 /// Trait which C2 profiles implement in order to connect to Mythic


### PR DESCRIPTION
Fixes issue where the agent fails to beacon after the initial checkin due to improper deserialization of the initial checkin response data.