### PR TITLE
Add support for offline builds

### DIFF
--- a/Payload_Type/thanatos/.docker/config.toml
+++ b/Payload_Type/thanatos/.docker/config.toml
@@ -6,3 +6,6 @@ replace-with = "vendored-sources"
 
 [source.vendored-sources]
 directory = "/vendor"
+
+[net]
+offline = true

--- a/Payload_Type/thanatos/.docker/config.toml
+++ b/Payload_Type/thanatos/.docker/config.toml
@@ -1,2 +1,8 @@
 [build]
 rustc-wrapper = "/usr/bin/sccache"
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "/Mythic/thanatos/agent_code/vendor"

--- a/Payload_Type/thanatos/Dockerfile
+++ b/Payload_Type/thanatos/Dockerfile
@@ -8,32 +8,32 @@ ENV SCCACHE_VERSION v0.7.6
 
 # Install packages
 RUN dnf install -y \
-        python3.11 \
-        python3-pip \
-        python3.11-devel \
-        mingw64-gcc \
-        mingw32-gcc \
-        mingw64-gcc-c++ \
-        mingw32-gcc-c++ \
-        mingw64-winpthreads-static.noarch \
-        mingw32-winpthreads-static.noarch \
-        libgcc.i686 \
-        libatomic-static.i686 \
-        libatomic.i686 \
-        glibc-devel.i686 \
-        openssl-devel \
-        openssl-devel.i686 \
-        perl-FindBin \
-        perl-File-Compare \
-        perl-IPC-Cmd \
-        perl-File-Copy \
-        perl-lib \
-        clang \
-        curl \
-        make \
-        musl-gcc \
-        musl-libc-static \
-        && dnf clean all
+    python3.11 \
+    python3-pip \
+    python3.11-devel \
+    mingw64-gcc \
+    mingw32-gcc \
+    mingw64-gcc-c++ \
+    mingw32-gcc-c++ \
+    mingw64-winpthreads-static.noarch \
+    mingw32-winpthreads-static.noarch \
+    libgcc.i686 \
+    libatomic-static.i686 \
+    libatomic.i686 \
+    glibc-devel.i686 \
+    openssl-devel \
+    openssl-devel.i686 \
+    perl-FindBin \
+    perl-File-Compare \
+    perl-IPC-Cmd \
+    perl-File-Copy \
+    perl-lib \
+    clang \
+    curl \
+    make \
+    musl-gcc \
+    musl-libc-static \
+    && dnf clean all
 
 RUN python3.11 -m ensurepip
 
@@ -48,13 +48,13 @@ RUN rm requirements.txt
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh \
     && sh rustup.sh -y \
-        --profile minimal \
-        --default-toolchain stable \
-        -t x86_64-unknown-linux-gnu \
-        -t i686-unknown-linux-gnu \
-        -t x86_64-unknown-linux-musl \
-        -t x86_64-pc-windows-gnu \
-        -t i686-pc-windows-gnu
+    --profile minimal \
+    --default-toolchain stable \
+    -t x86_64-unknown-linux-gnu \
+    -t i686-unknown-linux-gnu \
+    -t x86_64-unknown-linux-musl \
+    -t x86_64-pc-windows-gnu \
+    -t i686-pc-windows-gnu
 
 RUN rm -f rustup.sh
 

--- a/Payload_Type/thanatos/Dockerfile
+++ b/Payload_Type/thanatos/Dockerfile
@@ -77,15 +77,6 @@ COPY thanatos thanatos
 # Fetch dependencies
 WORKDIR /Mythic/thanatos/agent_code
 
-# Linux builds (no static linking)
-RUN cargo check --target x86_64-unknown-linux-gnu --release --all-features || true
-RUN cargo check --target i686-unknown-linux-gnu --release --all-features || true  
-# Linux builds (static)
-RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target x86_64-unknown-linux-musl --release --all-features || true
-#  Windows builds (always use crt-static)
-RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target x86_64-pc-windows-gnu --release --all-features || true
-RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target i686-pc-windows-gnu --release --all-features || true
-
 RUN cargo vendor /vendor
 
 WORKDIR /Mythic

--- a/Payload_Type/thanatos/Dockerfile
+++ b/Payload_Type/thanatos/Dockerfile
@@ -76,7 +76,17 @@ COPY thanatos thanatos
 
 # Fetch dependencies
 WORKDIR /Mythic/thanatos/agent_code
-RUN cargo fetch
+
+# Linux builds (no static linking)
+RUN cargo check --target x86_64-unknown-linux-gnu --release --all-features || true
+RUN cargo check --target i686-unknown-linux-gnu --release --all-features || true  
+# Linux builds (static)
+RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target x86_64-unknown-linux-musl --release --all-features || true
+#  Windows builds (always use crt-static)
+RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target x86_64-pc-windows-gnu --release --all-features || true
+RUN RUSTFLAGS="-C target-feature=+crt-static" cargo check --target i686-pc-windows-gnu --release --all-features || true
+
+RUN cargo vendor vendor
 
 WORKDIR /Mythic
 

--- a/config.json
+++ b/config.json
@@ -6,6 +6,6 @@
   "exclude_documentation_wrapper": true,
   "exclude_agent_icons": false,
   "remote_images": {
-    "thanatos": "ghcr.io/mythicagents/thanatos:v0.1.13"
+    "thanatos": "ghcr.io/nblair2/thanatos:v0.1.4"
   }
 }


### PR DESCRIPTION
This adds support for building the payload on an offline build server. Dependencies will get vendored and stored in the payload type container image during CI builds.

Resolves #46 